### PR TITLE
Settingsc screen fix #44

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,191 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+void showSettingsSheet(BuildContext context) {
+  HapticFeedback.mediumImpact();
+  showCupertinoSheet(
+  context: context,
+  enableDrag: true,
+  builder: (context) {
+    return NotificationListener<DraggableScrollableNotification>(
+      onNotification: (notification) {
+        if (notification.extent <= 0.41) {
+          Navigator.pop(context);
+          return true;
+        }
+        return false;
+      },
+      child: DraggableScrollableSheet(
+        initialChildSize: 0.50,
+        minChildSize: 0.40,
+        maxChildSize: 0.95,
+        expand: false,
+        builder: (context, scrollController) {
+          return SettingsSheet(
+            scrollController: scrollController,
+          );
+        },
+      ),
+    );
+  },
+);
+}
+
+class SettingsSheet extends StatelessWidget {
+  const SettingsSheet({super.key, required this.scrollController});
+
+  final ScrollController scrollController;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final bottomPadding = MediaQuery.of(context).padding.bottom;
+
+    return Material(
+      color: Colors.transparent,
+      child: ClipRRect(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 40, sigmaY: 40),
+          child: Container(
+            decoration: BoxDecoration(
+              color: colorScheme.surface.withOpacity(0.95),
+              borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+            ),
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                children: [
+                  Padding(
+                    padding: EdgeInsets.only(top: 12, bottom: 4),
+                    child: Container(
+                      width: 36,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: colorScheme.onSurface.withOpacity(0.2),
+                        borderRadius: BorderRadius.circular(100),
+                      ),
+                    ),
+                  ),
+
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(24, 16, 24, 8),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          'Settings',
+                          style: TextStyle(
+                            fontSize: 22,
+                            fontWeight: FontWeight.w500,
+                            color: colorScheme.onSurface,
+                          ),
+                        ),
+                        GestureDetector(
+                          onTap: () => Navigator.pop(context),
+                          child: Container(
+                            width: 32,
+                            height: 32,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: colorScheme.onSurface.withOpacity(0.1),
+                            ),
+                            child: Icon(
+                              Icons.close_rounded,
+                              size: 18,
+                              color: colorScheme.onSurface,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  SizedBox(height: 12),
+
+                  // ── Tiles ─────────────────────────────────────
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(24, 0, 24, bottomPadding + 40),
+                    child: Column(
+                      children: [
+                        _SettingsTile(
+                      icon: Icons.settings_outlined,
+                      label: 'Place Holder..',
+                      colorScheme: colorScheme,
+                    ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final ColorScheme colorScheme;
+
+  const _SettingsTile({
+    required this.icon,
+    required this.label,
+    required this.colorScheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.onSurface.withOpacity(0.05),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: () {},
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+            child: Row(
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: colorScheme.primary.withOpacity(0.35),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(icon, size: 20, color: colorScheme.primary),
+                ),
+                SizedBox(width: 14),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                    color: colorScheme.onSurface.withOpacity(0.85),
+                  ),
+                ),
+                Spacer(),
+                Icon(
+                  Icons.chevron_right_rounded,
+                  size: 20,
+                  color: colorScheme.onSurface.withOpacity(0.25),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,34 +4,59 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+
+class _DismissibleCupertinoSheetRoute<T> extends CupertinoSheetRoute<T> {
+  _DismissibleCupertinoSheetRoute({
+    required super.builder,
+    super.enableDrag,
+    Color barrierColor = const Color(0x73000000), // ~45% black
+  }) : _barrierColor = barrierColor;
+ 
+  final Color _barrierColor;
+ 
+  @override
+  Color? get barrierColor => _barrierColor;
+ 
+
+  @override
+  bool get barrierDismissible => true;
+ 
+
+  @override
+  String get barrierLabel => 'Dismiss';
+}
+
 void showSettingsSheet(BuildContext context) {
   HapticFeedback.mediumImpact();
-  showCupertinoSheet(
-  context: context,
-  enableDrag: true,
-  builder: (context) {
-    return NotificationListener<DraggableScrollableNotification>(
-      onNotification: (notification) {
-        if (notification.extent <= 0.41) {
-          Navigator.pop(context);
-          return true;
-        }
-        return false;
+ 
+  Navigator.of(context, rootNavigator: true).push(
+    _DismissibleCupertinoSheetRoute(
+      barrierColor: Colors.black.withOpacity(0.45),
+      builder: (sheetContext) {
+        return NotificationListener<DraggableScrollableNotification>(
+          onNotification: (notification) {
+            if (notification.extent <= notification.minExtent + 0.01) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (Navigator.canPop(sheetContext)) {
+                  Navigator.pop(sheetContext);
+                }
+              });
+            }
+            return false;
+          },
+          child: DraggableScrollableSheet(
+            initialChildSize: 0.50,
+            minChildSize: 0.40,
+            maxChildSize: 0.95,
+            expand: false,
+            builder: (context, scrollController) {
+              return SettingsSheet(scrollController: scrollController);
+            },
+          ),
+        );
       },
-      child: DraggableScrollableSheet(
-        initialChildSize: 0.50,
-        minChildSize: 0.40,
-        maxChildSize: 0.95,
-        expand: false,
-        builder: (context, scrollController) {
-          return SettingsSheet(
-            scrollController: scrollController,
-          );
-        },
-      ),
-    );
-  },
-);
+    ),
+  );
 }
 
 class SettingsSheet extends StatelessWidget {
@@ -58,7 +83,7 @@ class SettingsSheet extends StatelessWidget {
             child: SingleChildScrollView(
               controller: scrollController,
               child: Column(
-                mainAxisSize: MainAxisSize.max,
+                mainAxisSize: MainAxisSize.min,
                 children: [
                   Padding(
                     padding: EdgeInsets.only(top: 12, bottom: 4),
@@ -113,10 +138,10 @@ class SettingsSheet extends StatelessWidget {
                     child: Column(
                       children: [
                         _SettingsTile(
-                      icon: Icons.settings_outlined,
-                      label: 'Place Holder..',
-                      colorScheme: colorScheme,
-                    ),
+                          icon: Icons.settings_outlined,
+                          label: 'Place Holder..',
+                          colorScheme: colorScheme,
+                        ),
                       ],
                     ),
                   ),

--- a/lib/widget/home_screen/car_display.dart
+++ b/lib/widget/home_screen/car_display.dart
@@ -103,7 +103,7 @@ class _CarCarousel extends StatelessWidget {
                   
                   Icon(Icons.car_crash_outlined , color: Colors.redAccent,),
                   SizedBox(width: 10,),
-                  Text("Error while loading Image." ,
+                  Text("Image not available" ,
                     style: TextStyle(
                        fontFamily: 'Inter',
                     ),

--- a/lib/widget/home_screen/car_display.dart
+++ b/lib/widget/home_screen/car_display.dart
@@ -95,6 +95,22 @@ class _CarCarousel extends StatelessWidget {
           return Image.asset(
             'assets/images/png/car${index + 1}.png',
             fit: BoxFit.contain,
+             errorBuilder: (context, error, stackTrace) {
+              return Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  
+                  Icon(Icons.car_crash_outlined , color: Colors.redAccent,),
+                  SizedBox(width: 10,),
+                  Text("Error while loading Image." ,
+                    style: TextStyle(
+                       fontFamily: 'Inter',
+                    ),
+                  )
+                ],
+              ); // fallback widget
+            },
           );
         },
       ),

--- a/lib/widget/home_screen/header_bar.dart
+++ b/lib/widget/home_screen/header_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:redrive/screens/settings_screen.dart';
 
 class HeaderBar extends StatelessWidget {
   const HeaderBar({super.key});
@@ -94,9 +95,7 @@ class _SettingsButton extends StatelessWidget {
         child: Material(
           color: Colors.transparent,
           child: InkWell(
-            onTap: () {
-              /* TODO */
-            },
+            onTap: () => showSettingsSheet(context),
             borderRadius: BorderRadius.circular(100),
             child: Center(
               child: SvgPicture.asset(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -268,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -441,10 +441,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Overview

@iUnreallx 

This PR adds a Cupertino-style draggable settings sheet with smooth dismissal behavior and improved UI consistency.

## Changes Made

- Added `showCupertinoSheet` based settings modal
- Implemented draggable bottom sheet behavior using `DraggableScrollableSheet`
- Added swipe-down-to-dismiss functionality using `NotificationListener`
- Enabled smooth drag gestures with `enableDrag: true`
- Added glassmorphism blur background effect using `BackdropFilter`
- Added close button support for manual dismissal
- Connected sheet scrolling with `scrollController`
- Added responsive bottom padding support using `MediaQuery`
- Improved tile UI with ripple effects and rounded corners

## Result

The settings sheet now behaves much closer to a native iOS Cupertino modal sheet with:
- smooth drag interaction
- dismiss on swipe down
- premium blurred background
- cleaner typography
- improved touch feedback