### PR TITLE
fix: handle permanently denied Bluetooth permissions (#49)

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/models/bluetooth_enums.dart
+++ b/lib/models/bluetooth_enums.dart
@@ -1,0 +1,11 @@
+enum BluetoothPermissionStatus {
+  granted,
+  denied,
+  permanentlyDenied,
+}
+
+enum BluetoothScanResult {
+  started,
+  notStarted,
+  permanentlyDenied,
+}

--- a/lib/providers/bluetooth_provider.dart
+++ b/lib/providers/bluetooth_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer' as developer;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_classic/flutter_blue_classic.dart';
+import 'package:redrive/models/bluetooth_enums.dart';
 import 'package:redrive/services/bluetooth_permission_service.dart';
 import '../models/obd_device.dart';
 
@@ -111,104 +112,101 @@ class BluetoothProvider extends ChangeNotifier {
   }
 
   /// Сканирование блютуз в округе
-  Future<bool> startScan() async {
-    if (_isScanning) return true;
 
-    developer.log("Запрашиваем доступ к разрешениям", name: 'reBlue');
-    final permissionsGranted = await requestBluetoothPermissions();
+  Future<BluetoothScanResult> startScan() async {
+  if (_isScanning) return BluetoothScanResult.started;
 
-    if (!permissionsGranted) {
-      _isScanning = false;
-      notifyListeners();
-      return false;
+  developer.log("Запрашиваем доступ к разрешениям", name: 'reBlue');
+  final permissionStatus = await requestBluetoothPermissions();
+
+  if (permissionStatus == BluetoothPermissionStatus.permanentlyDenied) {
+    return BluetoothScanResult.permanentlyDenied;
+  }
+
+  if (permissionStatus != BluetoothPermissionStatus.granted) {
+    _isScanning = false;
+    notifyListeners();
+    return BluetoothScanResult.notStarted;
+  }
+
+  if (!_isHardwareOn) {
+    _pendingScan = true;
+    try {
+      _bluetooth.turnOn();
+    } catch (e) {
+      developer.log("Ошибка вызова turnOn: $e", name: 'reBlue', error: e);
     }
+    return BluetoothScanResult.notStarted;
+  }
 
-    if (!_isHardwareOn) {
-      _pendingScan = true;
-      try {
-        _bluetooth.turnOn();
-      } catch (e) {
-        developer.log("Ошибка вызова turnOn: $e", name: 'reBlue', error: e);
+  _isToggleOn = true;
+  _isScanning = true;
+  _pendingScan = false;
+
+  final activePhysicalDevice = (_isConnected && _connectedDevice != null)
+      ? _deviceMap[_connectedDevice!.address]
+      : null;
+
+  _discoveredDevices.clear();
+  _deviceMap.clear();
+
+  if (activePhysicalDevice != null && _connectedDevice != null) {
+    _deviceMap[activePhysicalDevice.address] = activePhysicalDevice;
+    _discoveredDevices.add(_connectedDevice!);
+  }
+
+  notifyListeners();
+
+  try {
+    try {
+      final bonded = await _bluetooth.bondedDevices;
+      if (bonded != null) {
+        for (final device in bonded) {
+          _addDeviceToList(device);
+        }
       }
-      return false;
-    }
-
-    _isToggleOn = true;
-    _isScanning = true;
-    _pendingScan = false;
-
-    final activePhysicalDevice = (_isConnected && _connectedDevice != null)
-        ? _deviceMap[_connectedDevice!.address]
-        : null;
-
-    _discoveredDevices.clear();
-    _deviceMap.clear();
-
-    if (activePhysicalDevice != null && _connectedDevice != null) {
-      _deviceMap[activePhysicalDevice.address] = activePhysicalDevice;
-      _discoveredDevices.add(_connectedDevice!);
+    } catch (e) {
+      developer.log("Ошибка получения bonded devices", name: 'reBlue', error: e);
     }
 
     notifyListeners();
 
-    try {
-      try {
-        final bonded = await _bluetooth.bondedDevices;
-        if (bonded != null) {
-          for (final device in bonded) {
-            _addDeviceToList(device);
-          }
-        }
-      } catch (e) {
-        developer.log(
-          "Ошибка получения bonded devices",
-          name: 'reBlue',
-          error: e,
-        );
-      }
+    _bluetooth.startScan();
+    developer.log("Сканирование запущено", name: 'reBlue');
 
-      notifyListeners();
-
-      _bluetooth.startScan();
-      developer.log("Сканирование запущено", name: 'reBlue');
-
-      await _scanSubscription?.cancel();
-      _scanSubscription = _bluetooth.scanResults.listen(
-        (BluetoothDevice device) {
-          if (!_deviceMap.containsKey(device.address)) {
-            _addDeviceToList(
-              device,
-              connected: _connectedDevice?.address == device.address,
-            );
-            notifyListeners();
-          }
-        },
-        onError: (err) {
-          developer.log(
-            "Ошибка в стриме сканирования",
-            name: 'reBlue',
-            error: err,
+    await _scanSubscription?.cancel();
+    _scanSubscription = _bluetooth.scanResults.listen(
+      (BluetoothDevice device) {
+        if (!_deviceMap.containsKey(device.address)) {
+          _addDeviceToList(
+            device,
+            connected: _connectedDevice?.address == device.address,
           );
-          _stopScan();
-        },
-      );
-
-      _scanTimer?.cancel();
-      _scanTimer = Timer(const Duration(seconds: 15), () {
-        if (_isScanning) {
-          developer.log("Таймер: 15 секунд прошло, авто-стоп", name: 'reBlue');
-          _stopScan();
+          notifyListeners();
         }
-      });
-    } catch (e) {
-      developer.log("Scan error: $e", name: 'reBlue', error: e);
-      _isScanning = false;
-      notifyListeners();
-      return false;
-    }
+      },
+      onError: (err) {
+        developer.log("Ошибка в стриме сканирования", name: 'reBlue', error: err);
+        _stopScan();
+      },
+    );
 
-    return true;
+    _scanTimer?.cancel();
+    _scanTimer = Timer(const Duration(seconds: 15), () {
+      if (_isScanning) {
+        developer.log("Таймер: 15 секунд прошло, авто-стоп", name: 'reBlue');
+        _stopScan();
+      }
+    });
+  } catch (e) {
+    developer.log("Scan error: $e", name: 'reBlue', error: e);
+    _isScanning = false;
+    notifyListeners();
+    return BluetoothScanResult.notStarted;
   }
+
+  return BluetoothScanResult.started;
+}
 
   /// Останавливает сканирование и сбрасывает связанные таймеры и подписки
   Future<void> _stopScan() async {

--- a/lib/services/bluetooth_permission_service.dart
+++ b/lib/services/bluetooth_permission_service.dart
@@ -1,9 +1,12 @@
 import 'dart:io';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:redrive/models/bluetooth_enums.dart';
 
-Future<bool> requestBluetoothPermissions() async {
-  if (!Platform.isAndroid) return true;
+Future<BluetoothPermissionStatus> requestBluetoothPermissions() async {
+
+
+  if (!Platform.isAndroid) return BluetoothPermissionStatus.granted;
 
   final deviceInfo = DeviceInfoPlugin();
   final androidInfo = await deviceInfo.androidInfo;
@@ -26,6 +29,12 @@ Future<bool> requestBluetoothPermissions() async {
     statuses = await [Permission.location].request();
   }
 
-  final granted = statuses.values.every((s) => s.isGranted);
-  return granted;
+  final isPermanentlyDenied =
+      statuses.values.any((s) => s.isPermanentlyDenied);
+  if (isPermanentlyDenied) return BluetoothPermissionStatus.permanentlyDenied;
+
+  final isGranted = statuses.values.every((s) => s.isGranted);
+  return isGranted
+      ? BluetoothPermissionStatus.granted
+      : BluetoothPermissionStatus.denied;
 }

--- a/lib/widget/connection/bluetooth/bluetooth_tab.dart
+++ b/lib/widget/connection/bluetooth/bluetooth_tab.dart
@@ -95,7 +95,7 @@ class _BluetoothTabState extends State<BluetoothTab> {
       children: [
         BluetoothScanStatusCard(onRefresh: () => _handleScan(context)),
         SizedBox(height: 20),
-        Expanded(child: BluetoothDevicePanel(onScan: () => _handleScan)),
+        Expanded(child: BluetoothDevicePanel(onScan: () => _handleScan(context))),
       ],
     );
   }

--- a/lib/widget/connection/bluetooth/bluetooth_tab.dart
+++ b/lib/widget/connection/bluetooth/bluetooth_tab.dart
@@ -25,7 +25,7 @@ class _BluetoothTabState extends State<BluetoothTab> {
       if (!provider.isScanning && !provider.isConnected) {
         Future.delayed(const Duration(milliseconds: 50), () {
           if (!mounted) return;
-          context.read<BluetoothProvider>().startScan();
+          _handleScan(context);
         });
       }
     });
@@ -56,6 +56,7 @@ class _BluetoothTabState extends State<BluetoothTab> {
           'Please enable it from app settings.',
           style: TextStyle(color: Colors.white54),
         ),
+        actionsAlignment: MainAxisAlignment.center,
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(),
@@ -92,7 +93,7 @@ class _BluetoothTabState extends State<BluetoothTab> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        BluetoothScanStatusCard(onRefresh: () => _handleScan),
+        BluetoothScanStatusCard(onRefresh: () => _handleScan(context)),
         SizedBox(height: 20),
         Expanded(child: BluetoothDevicePanel(onScan: () => _handleScan)),
       ],

--- a/lib/widget/connection/bluetooth/bluetooth_tab.dart
+++ b/lib/widget/connection/bluetooth/bluetooth_tab.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
+import 'package:redrive/models/bluetooth_enums.dart';
 import 'package:redrive/models/obd_device.dart';
 import 'package:redrive/providers/bluetooth_provider.dart';
 
@@ -29,13 +31,70 @@ class _BluetoothTabState extends State<BluetoothTab> {
     });
   }
 
+  Future<void> _handleScan(BuildContext context) async {
+    final result = await context.read<BluetoothProvider>().startScan();
+    if (!mounted) return;
+
+    if (result == BluetoothScanResult.permanentlyDenied) {
+      _showPermissionDialog(context);
+    }
+    // started aur notStarted ke liye kuch nahi karna
+  }
+
+  void _showPermissionDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: const Color(0xFF131315),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+        title: const Text(
+          'Bluetooth access required',
+          style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+        ),
+        content: const Text(
+          'Bluetooth permission was permanently denied. '
+          'Please enable it from app settings.',
+          style: TextStyle(color: Colors.white54),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text(
+              'Cancel',
+              style: TextStyle(color: Colors.white54),
+            ),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              openAppSettings(); // permission_handler se aata hai
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFC4FF47),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(100),
+              ),
+            ),
+            child: const Text(
+              'Open settings',
+              style: TextStyle(
+                color: Colors.black,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Column(
+    return Column(
       children: [
-        BluetoothScanStatusCard(),
+        BluetoothScanStatusCard(onRefresh: () => _handleScan),
         SizedBox(height: 20),
-        Expanded(child: BluetoothDevicePanel()),
+        Expanded(child: BluetoothDevicePanel(onScan: () => _handleScan)),
       ],
     );
   }
@@ -44,7 +103,8 @@ class _BluetoothTabState extends State<BluetoothTab> {
 /// Карточка статуса сканирования.
 /// Слушает только isScanning и количество найденных устройств.
 class BluetoothScanStatusCard extends StatelessWidget {
-  const BluetoothScanStatusCard({super.key});
+  final VoidCallback onRefresh;
+  const BluetoothScanStatusCard({super.key, required this.onRefresh});
 
   @override
   Widget build(BuildContext context) {
@@ -65,14 +125,12 @@ class BluetoothScanStatusCard extends StatelessWidget {
         ),
         child: InkWell(
           borderRadius: BorderRadius.circular(20),
-          onTap: () async {
-            if (!isScanning) {
-              Future.delayed(const Duration(milliseconds: 150), () {
-                if (!context.mounted) return;
-                context.read<BluetoothProvider>().startScan();
-              });
-            }
-          },
+          onTap: isScanning
+              ? null
+              : () => Future.delayed(
+                  const Duration(milliseconds: 150),
+                  onRefresh, // _handleScan pass hoga
+                ),
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Row(
@@ -151,7 +209,8 @@ class BluetoothScanStatusCard extends StatelessWidget {
 
 /// Основная панель со списком Bluetooth-устройств.
 class BluetoothDevicePanel extends StatelessWidget {
-  const BluetoothDevicePanel({super.key});
+   final VoidCallback onScan;
+  const BluetoothDevicePanel({super.key, required this.onScan});
 
   @override
   Widget build(BuildContext context) {
@@ -160,10 +219,10 @@ class BluetoothDevicePanel extends StatelessWidget {
         color: const Color(0xFF131315),
         borderRadius: BorderRadius.circular(24),
       ),
-      child: const Column(
+      child: Column(
         children: [
           BluetoothModeSwitcher(),
-          Expanded(child: BluetoothDeviceList()),
+          Expanded(child: BluetoothDeviceList(onScan: onScan)),
         ],
       ),
     );
@@ -222,7 +281,8 @@ class BluetoothModeSwitcher extends StatelessWidget {
 /// - количество устройств;
 /// - имя или адрес устройства.
 class BluetoothDeviceList extends StatelessWidget {
-  const BluetoothDeviceList({super.key});
+  final VoidCallback onScan;
+  const BluetoothDeviceList({super.key, required this.onScan});
 
   @override
   Widget build(BuildContext context) {
@@ -279,8 +339,7 @@ class BluetoothDeviceList extends StatelessWidget {
                   width: 200,
                   height: 50,
                   child: ElevatedButton(
-                    onPressed: () =>
-                        context.read<BluetoothProvider>().startScan(),
+                    onPressed: onScan,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: const Color(0xFFC4FF47),
                       shape: RoundedRectangleBorder(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -268,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -441,10 +441,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
Resolves #49 handles the case where the user has permanently denied 
Bluetooth permissions by showing a dialog with an option to open app settings.

## Changes

### `lib/models/enums/enum.dart` (new file)
Centralized enums to avoid circular dependencies between provider and service.
- `BluetoothPermissionStatus` — granted, denied, permanentlyDenied
- `BluetoothScanResult` — started, notStarted, permanentlyDenied

### `lib/services/bluetooth_permission_service.dart`
- Return type changed from `bool` to `BluetoothPermissionStatus`
- Existing Android SDK version logic (31+ / 29+ / older) preserved as-is
- Added `isPermanentlyDenied` check before `isGranted` check

### `lib/providers/bluetooth_provider.dart`
- `startScan()` return type changed from `Future<bool>` to `Future<BluetoothScanResult>`
- `true` → `BluetoothScanResult.started`
- `false` (normal denial / hardware off) → `BluetoothScanResult.notStarted`
- permanently denied → `BluetoothScanResult.permanentlyDenied`

### `lib/widget/connection/bluetooth/bluetooth_tab.dart`
- All three `startScan()` call sites (initState, refresh card, start scanning button) 
  wrapped into single `_handleScan()` helper
- `permanentlyDenied` result shows dialog with "Open settings" button via `openAppSettings()`
- Other results keep existing behavior

## Testing
- Added unit tests for permission status resolution logic
- Added unit tests for scan result resolution logic  
- Added widget tests for dialog behavior on all three scan results

## Branch
`fix/49-bluetooth-denied-permissions`